### PR TITLE
[TASK] Change default cache backend to File

### DIFF
--- a/Configuration/Production/Caches.yaml
+++ b/Configuration/Production/Caches.yaml
@@ -1,13 +1,7 @@
 Ttree_Oembed_Resource_Cache:
   frontend: TYPO3\Flow\Cache\Frontend\VariableFrontend
-  backend: TYPO3\Flow\Cache\Backend\MemcachedBackend
-  backendOptions:
-    defaultLifetime: 3600
-    servers: [ "127.0.0.1:11211" ]
+  backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend
 
 Ttree_Oembed_EndPoint_Cache:
   frontend: TYPO3\Flow\Cache\Frontend\StringFrontend
-  backend: TYPO3\Flow\Cache\Backend\MemcachedBackend
-  backendOptions:
-    defaultLifetime: 3600
-    servers: [ "127.0.0.1:11211" ]
+  backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend


### PR DESCRIPTION
In Production the SimpleFileBackend is the new default to avoid breaking if this package is installed on machines that do not provide Memcached.
